### PR TITLE
Mod : Example 16-17 grouper optimization

### DIFF
--- a/16-coroutine/coroaverager3.py
+++ b/16-coroutine/coroaverager3.py
@@ -63,8 +63,11 @@ def averager():  # <1>
 
 # the delegating generator
 def grouper(results, key):  # <5>
-    while True:  # <6>
-        results[key] = yield from averager()  # <7>
+    # while True:       # <6>
+    results[key] = yield from averager()  # <7>
+    # When group.send(None) is called, group runs to the yield statement below 
+    # without raising StopIteration and creating a useless new instance of averager  
+    yield
 
 
 # the client code, a.k.a. the caller


### PR DESCRIPTION
The delegating generator grouper delegates averager inside a while loop.
Every time averager returns, a new but useless averager instance will be created during the following loop period.
Adding a `yield` statement after `yield from averager()` without while loop could be better, in my opinion. 
Great great book, by the way.