### PR TITLE
Tests should use a separate shelve test database

### DIFF
--- a/19-dyn-attr-prop/oscon/test_schedule1.py
+++ b/19-dyn-attr-prop/oscon/test_schedule1.py
@@ -1,15 +1,20 @@
+import os
 import shelve
+
 import pytest
 
 import schedule1 as schedule
 
+DB_NAME = 'data/test_db'
 
-@pytest.yield_fixture
+
+@pytest.fixture(scope='module')
 def db():
-    with shelve.open(schedule.DB_NAME) as the_db:
+    with shelve.open(DB_NAME) as the_db:
         if schedule.CONFERENCE not in the_db:
             schedule.load_db(the_db)
         yield the_db
+        os.remove(DB_NAME)
 
 
 def test_record_class():

--- a/19-dyn-attr-prop/oscon/test_schedule2.py
+++ b/19-dyn-attr-prop/oscon/test_schedule2.py
@@ -1,15 +1,18 @@
+import os
 import shelve
+
 import pytest
 
 import schedule2 as schedule
 
 
-@pytest.yield_fixture
+@pytest.fixture(scope='module')
 def db():
-    with shelve.open(schedule.DB_NAME) as the_db:
+    with shelve.open(DB_NAME) as the_db:
         if schedule.CONFERENCE not in the_db:
             schedule.load_db(the_db)
         yield the_db
+        os.remove(DB_NAME)
 
 
 def test_record_attr_access():


### PR DESCRIPTION
While trying to run the tests locally, I ran into errors when pickle tried to load the already existing database. I think it would be nice if readers do not have to waste any time with this error.

This PR fixes that by creating a temporary database before any tests in the module run and deleting it afterwards. I also took the liberty of switching from the deprecated `@pytest.yield_fixture` to `@pytest.fixture`.

Thanks for a wonderful book 😃.