### PR TITLE
modified Vector v4 equality check

### DIFF
--- a/10-seq-hacking/vector_v4.py
+++ b/10-seq-hacking/vector_v4.py
@@ -160,6 +160,7 @@ class Vector:
 
     def __init__(self, components):
         self._components = array(self.typecode, components)
+        self._hash = None
 
     def __iter__(self):
         return iter(self._components)
@@ -177,12 +178,17 @@ class Vector:
                 bytes(self._components))
 
     def __eq__(self, other):
-        return (len(self) == len(other) and
+        return (hash(self) == hash(other) and len(self) == len(other) and
                 all(a == b for a, b in zip(self, other)))
 
     def __hash__(self):
+        if self._hash:
+            return self._hash
+
         hashes = (hash(x) for x in self)
-        return functools.reduce(operator.xor, hashes, 0)
+        self._hash = functools.reduce(operator.xor, hashes, 0)
+        
+        return self._hash
 
     def __abs__(self):
         return math.sqrt(sum(x * x for x in self))


### PR DESCRIPTION
According to my understanding of hashing and equality, I tried to enhance the performance of equality checking by ensuring that `__eq__` does not perform component based comparison  only if vectors has the same hash values (if two hashes is different then the two vectors are definitely unequal). because if two vectors has same hash value then:

-        either they equal 
-        they are not equal `Vector(1, 0, -1)`  and  `Vector(1, -1, 0)` will have the same hash value of -2
