### PR TITLE
Add argument to str.format on line 11

### DIFF
--- a/09-pythonic-obj/mem_test.py
+++ b/09-pythonic-obj/mem_test.py
@@ -8,7 +8,7 @@ if len(sys.argv) == 2:
     module_name = sys.argv[1].replace('.py', '')
     module = importlib.import_module(module_name)
 else:
-    print('Usage: {} <vector-module-to-test>'.format())
+    print('Usage: {} <vector-module-to-test>'.format(sys.argv[0]))
     sys.exit(1)
 
 fmt = 'Selected Vector2d type: {.__name__}.{.__name__}'


### PR DESCRIPTION
Without an argument, the usage statement generated an IndexError exception when calling the print() function. Adding the 'sys.argv[0]' argument to str.format solves the problem.