### PR TITLE
docs: fix simple typo, shorcut -> shortcut

### DIFF
--- a/18-asyncio/charfinder/charfinder.py
+++ b/18-asyncio/charfinder/charfinder.py
@@ -163,7 +163,7 @@ class UnicodeNameIndex:
         result_sets = []
         for word in tokenize(query):
             chars = self.index.get(word)
-            if chars is None:  # shorcut: no such word
+            if chars is None:  # shortcut: no such word
                 result_sets = []
                 break
             result_sets.append(chars)

--- a/attic/concurrency/charfinder/charfinder.py
+++ b/attic/concurrency/charfinder/charfinder.py
@@ -165,7 +165,7 @@ class UnicodeNameIndex:
         for word in tokenize(query):
             if word in self.index:
                 result_sets.append(self.index[word])
-            else:  # shorcut: no such word
+            else:  # shortcut: no such word
                 result_sets = []
                 break
         if result_sets:


### PR DESCRIPTION
There is a small typo in 18-asyncio/charfinder/charfinder.py, attic/concurrency/charfinder/charfinder.py.

Should read `shortcut` rather than `shorcut`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md